### PR TITLE
Fix for #7 - problem with initializing CAS

### DIFF
--- a/src/Xavrsl/Cas/Sso.php
+++ b/src/Xavrsl/Cas/Sso.php
@@ -124,19 +124,17 @@ class Sso {
         if($this->config['cas_proxy'])
         {
             $this->configureCasProxy();
+            $this->configureSslValidation();
         }
         else
         {
             $this->configureCasClient();
-
+            $this->configureSslValidation();
             $this->detect_authentication();
         }
 
         // set service URL for authorization with CAS server
         //\phpCAS::setFixedServiceURL();
-
-        $this->configureSslValidation();
-
 
         if (!empty($this->config['cas_service'])) {
             phpCAS::allowProxyChain(new \CAS_ProxyChain_Any);


### PR DESCRIPTION
This fixes #7 which causes:
phpCAS error: phpCAS::isAuthenticated(): one of the methods phpCAS::setCasServerCACert() or phpCAS::setNoCasServerValidation() must be called. in ........../vendor/xavrsl/cas/src/Xavrsl/Cas/Sso.php on line 199

In short, you need to configure SSL validation before attempting to detect_authentication.
