### PR TITLE
Backwards compatibility

### DIFF
--- a/src/Xavrsl/Cas/Sso.php
+++ b/src/Xavrsl/Cas/Sso.php
@@ -147,7 +147,8 @@ class Sso {
         $this->configureSslValidation();
 
         //set the postAuthenticateCallback function if it exists
-        if($this->config['cas_post_authenticate_callback'])
+        if(isset($this->config['cas_post_authenticate_callback']) 
+            && $this->config['cas_post_authenticate_callback'])
         {
             phpCAS::setPostAuthenticateCallback($this->config['cas_post_authenticate_callback']);
         }


### PR DESCRIPTION
Backwards compatibility with projects that don't have the cas_post_authenticate_callback config entry.

It was throwing an exception in all our projects with config files without this key.