### PR TITLE
Remove self signed cert option

### DIFF
--- a/src/Xavrsl/Cas/Sso.php
+++ b/src/Xavrsl/Cas/Sso.php
@@ -85,11 +85,7 @@ class Sso {
     private function configureSslValidation()
     {
         // set SSL validation for the CAS server
-        if ($this->config['cas_validation'] == 'self')
-        {
-            phpCAS::setCasServerCert($this->config['cas_cert']);
-        }
-        else if ($this->config['cas_validation'] == 'ca')
+        if ($this->config['cas_validation'] == 'ca' || $this->config['cas_validation'] == 'self')
         {
             phpCAS::setCasServerCACert($this->config['cas_cert']);
         }

--- a/src/config/cas.php
+++ b/src/config/cas.php
@@ -55,8 +55,8 @@ return [
         | CAS Validation
         |--------------------------------------------------------------------------
         |
-        | CAS server SSL validation: 'self' for self-signed certificate, 'ca' for
-        | certificate from a CA, empty for no SSL validation.
+        | CAS server SSL validation: 'ca' for certificate from a CA or self-signed
+        | certificate, empty for no SSL validation.
         |
         */
 


### PR DESCRIPTION
Fix: The ["bogus `setCasServerCert` function" has been removed from phpCAS](https://github.com/Jasig/phpCAS/blob/bba7b07f42adbef2ef116064304572f120f65535/docs/ChangeLog#L148). Use `setCasServerCACert()` for self-signed certs.

Backwards Compatibility: `configureSslValidation()` still checks for `self` as `cas_validation` option and uses `setCasServerCACert()`.

Test: Currently using a self signed cert in dev with the `cas_validation` option set to `ca`. Everything's working great and we're getting attributes back from Cas against an https wildcard.