### PR TITLE
Remove double call to initializeCas

### DIFF
--- a/src/Xavrsl/Cas/Sso.php
+++ b/src/Xavrsl/Cas/Sso.php
@@ -228,10 +228,6 @@ class Sso {
     {
         if($this->isPretending()) return true;
 
-        if(!phpCAS::isAuthenticated())
-        {
-            $this->initializeCas();
-        }
         phpCAS::logout($params);
         exit;
     }


### PR DESCRIPTION
Because initializeCas() is a part of the constructor, it is guaranteed to have run before the logout function.  I use Laravel sessions so I kill the local CAS session immediately after login, but unless the user specifically requests a logout, I don't kill the session at the server.  (Thus, I always call logout with no current authenticated user.) 

Currently this results in a PHP error:

     phpCAS error: phpCAS::client(): phpCAS::client() has already been called (at /home/vagrant/Code/.../vendor/xavrsl/cas/src/Xavrsl/Cas/Sso.php:76) in /home/vagrant/Code/.../vendor/xavrsl/cas/src/Xavrsl/Cas/Sso.php on line 76

because initializeCas has been called twice and wich calls ``$this->configureCasClient();`` twice which calls ``phpCAS::client()`` twice and creates the PHP error.

So if we just remove that if block, everything is happy if the user isn't logged in currently.  The if block didn't execute if a user was logged in so it should work in all cases now.