### PR TITLE
remove version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.*|5.*",
-        "jasig/phpcas": "1.3.3"
+        "jasig/phpcas": "1.3.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
there's typo bug on jasig/phpcas where class is not found,
and got through on 1.3.3. releases

here's the detailed line:
https://github.com/Jasig/phpCAS/blob/b6f5d484735d3b0e80b068a87bd1eabac04b2cbe/source/CAS/Client.php#L892